### PR TITLE
remove the php notice: undefined index

### DIFF
--- a/disable-http-calls.php
+++ b/disable-http-calls.php
@@ -46,8 +46,12 @@ class RC_Disable_HTTP_Calls {
      */
     public static function settings() {
 		
+		//avoid php notice: undefined index
+		if( ! isset( $_GET['http_calls'] ) ) {
+			return;
+		}
 		// Update value
-		$action = $_GET['http_calls'];
+		$action =  $_GET['http_calls'];
 		
 		if( $action == 'on' ) {
 			update_option( 'http_calls', 1 );


### PR DESCRIPTION
I got this error in my console:
Undefined index: http_calls in /srv/www/wordpress-default/wp-content/plugins/disable-http-calls/disable-http-calls.php on line 50
